### PR TITLE
Add arm64 build to fix seccomp error on macOS and update to Elasticsearch 8.16.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,4 @@ jobs:
           context: '.'
           push:    true
           tags:    'ghcr.io/occrp/alfred-elasticsearch:${{ github.sha }}'
+          platforms: 'linux/arm64,linux/amd64'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:8.16.0
+FROM --platform=$BUILDPLATFORM elasticsearch:8.16.1
 LABEL org.opencontainers.image.source="https://github.com/occrp/alfred-elasticsearch"
 
 RUN bin/elasticsearch-plugin install --batch analysis-icu


### PR DESCRIPTION
With arm64, we should be able to mitigate seccomp unavailable error when starting up Elasticsearch. See https://github.com/docker/for-mac/issues/7410