### PR TITLE
downgrade to 8.15.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM elasticsearch:8.16.1
+FROM --platform=$BUILDPLATFORM elasticsearch:8.15.5
 LABEL org.opencontainers.image.source="https://github.com/occrp/alfred-elasticsearch"
 
 RUN bin/elasticsearch-plugin install --batch analysis-icu


### PR DESCRIPTION
This fixes a compatibility issue causing ES to crash locally on MacOS M2/M3 laptops due to an problem related to `SECCOMP`. 
This error causes a full container crash in `8.16`, while it's just a warning in `8.15.15`

```
elasticsearch-1  | {"@timestamp":"2024-11-28T15:21:21.014Z", "log.level": "WARN", "message":"unable to install syscall filter: ", "ecs.version": "1.2.0","service.name":"ES_ECS","event.dataset":"elasticsearch.server","process.thread.name":"main","log.logger":"org.elasticsearch.bootstrap.JNANatives","elasticsearch.node.name":"51f45f926bce","elasticsearch.cluster.name":"docker-cluster","error.type":"java.lang.UnsupportedOperationException","error.message":"seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed","error.stack_trace":"java.lang.UnsupportedOperationException: seccomp unavailable: CONFIG_SECCOMP not compiled into kernel, CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER are needed\n\tat
```

Creating a follow-up issue on this repo to upgrade to 8.16